### PR TITLE
Add GetAll function to cached stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ go-common
       "dbTypeName": "DbPerson", // stored and returned type: models.{dbTypeName}
       "bucketName": "people",   // object store bucket name
       "version": "v1",          // change this if the stored data structure is changed
+      "getAll": false,          // enable to generate code for listing all objects
       "secondaryIndexes": [     // generate additional Get methods
       	// GetByPhone, builds index on models.{dbTypeName}.Phone
         { "key": "Phone", "type": "unique" },
@@ -72,5 +73,5 @@ go run ./script/tofile --root=./files
 # assuming encrypted bucket
 $ ls -1 ./files | gp run ./script/fromfile | \
 ENCRYPTION_KEY=256bit-key go run ./script/encrypt | \
-MINIO_SECRET=minioadmin go run ./script/objcopy --to=../service/config/local-stage.json
+MINIO_SECRET=minioadmin go run ./script/objcopy --to=../service/config/local-stage.json --bucket=people
 ```

--- a/storagegen/main.go
+++ b/storagegen/main.go
@@ -22,7 +22,7 @@ type BucketSpec struct {
 	Template         string
 	Version          string
 	IdName           *string
-	InclPartnerID    *bool
+	GetAll           *bool
 	Config           *common.ObjectStoreConfig
 }
 
@@ -77,9 +77,9 @@ func main() {
 		if b.Config != nil {
 			config = *b.Config
 		}
-		inclPartnerID := true // default to true
-		if b.InclPartnerID != nil {
-			inclPartnerID = *b.InclPartnerID
+		getAll := false // default to false
+		if b.GetAll != nil {
+			getAll = *b.GetAll
 		}
 		// Patch secondary index default values
 		for i, idx := range b.SecondaryIndexes {
@@ -113,13 +113,14 @@ func main() {
 			SecondaryIndexes: b.SecondaryIndexes,
 			IdName:           idName,
 			Version:          b.Version,
-			InclPartnerID:    inclPartnerID,
 			Config:           config,
+			GetAll:           getAll,
 		})
 
 		// go codeconv uses _ in filenames
 		filename := fmt.Sprintf("%s.gen.go", strings.Replace(b.BucketName, "-", "_", -1))
-		err := ioutil.WriteFile(path.Join(dir, filename), bytes, 0644)
+		filepath := path.Join(dir, filename)
+		err := ioutil.WriteFile(filepath, bytes, 0644)
 		if err != nil {
 			zl.Fatal().Str("err", err.Error()).Msg("failed to load minio template")
 		}
@@ -177,8 +178,8 @@ type TmplParams struct {
 	IdName           string
 	Version          string
 	SecondaryIndexes []SecondaryIndex
-	InclPartnerID    bool
 	Config           common.ObjectStoreConfig
+	GetAll           bool
 }
 
 type TmplParams2 struct {

--- a/storagegen/tmpl/cachedstore.tmpl
+++ b/storagegen/tmpl/cachedstore.tmpl
@@ -28,7 +28,10 @@ import (
 const {{$cacheKey}}ID = "{{.IdName | ToLower }}"
 {{range .SecondaryIndexes -}}
 const {{$cacheKey}}{{.Name}} = "{{.CacheKey}}"
-{{end}}
+{{end -}}
+{{if .GetAll -}}
+const {{$cacheKey}}All = "_all"
+{{- end }}
 
 var {{$storeName}}Config common.ObjectStoreConfig
 func init() {
@@ -56,6 +59,9 @@ type {{.TypeName}}Cache interface {
 	Put(models.{{.DbTypeName}}, time.Duration, string) *common.Error
 	Get(string) (*models.{{.DbTypeName}}, string, *common.Error)
 	Delete(string) *common.Error
+	{{if .GetAll -}}
+	GetAll() ([]models.{{$modelName}}, string, *common.Error)
+	{{- end}}
 
 	// Secondary index operations
 	{{- range .SecondaryIndexes -}}
@@ -143,6 +149,13 @@ func (s *{{$storeName}}) Create(ctx context.Context, obj models.{{.DbTypeName}})
 func (s *{{$storeName}}) Get(id string) (*models.{{.DbTypeName}}, string, *common.Error) {
 	return s.cache.Get(id)
 }
+
+{{if .GetAll -}}
+// GetAll loads all objects from this store.
+func (s *{{$storeName}}) GetAll() ([]models.{{.DbTypeName}}, string, *common.Error) {
+	return s.cache.GetAll()
+}
+{{- end }}
 
 // Put updates or creates the object in both cache and backing store.
 func (s *{{$storeName}}) Put(ctx context.Context, obj models.{{.DbTypeName}}) *common.Error {
@@ -394,6 +407,16 @@ func (c {{$cacheName}}) Put(obj models.{{.DbTypeName}}, expiration time.Duration
 		return lerr
 	}
 
+	{{ if .GetAll -}}
+	// Primary index for all objects set: people.v1.all=all
+	// ETag index for all objects set: people.v1.etag.all=all
+	c.Leader.SAdd(context.TODO(), c.Key({{$cacheKey}}All, {{$cacheKey}}All), obj.{{$ID}})
+	err := c.Leader.Incr(context.TODO(), c.ETagKey({{$cacheKey}}All, {{$cacheKey}}All)).Err()
+	if err != nil {
+		return common.NewErrorE(http.StatusInternalServerError, err)
+	}
+	{{- end }}
+
 	{{- /* Update unique secondary indexes */ -}}
 	{{range .SecondaryIndexes -}}
 	{{if eq .Type "unique"}}
@@ -547,6 +570,32 @@ func (c *{{$cacheName}}) GetAllBy{{.Name}}(key string) ([]models.{{$modelName}},
 {{end -}}
 {{end}}
 
+{{ if .GetAll -}}
+// GetAll fetches all cached {{$modelName}}s
+func (c *{{$cacheName}}) GetAll() ([]models.{{$modelName}}, string, *common.Error) {
+	keys, err := c.Follower.SMembers(context.TODO(), c.Key({{$cacheKey}}All, {{$cacheKey}}All)).Result()
+	if err != nil {
+		return nil, "", common.NewErrorE(http.StatusInternalServerError, err)
+	}
+
+	objs := make([]models.{{$modelName}}, 0, 5)
+	for _, key := range keys {
+		obj, _, err := c.Get(key)
+		if err != nil {
+			return nil, "", err
+		}
+		objs = append(objs, *obj)
+	}
+
+	etag, err := c.Follower.Get(context.TODO(), c.ETagKey({{$cacheKey}}All, {{$cacheKey}}All)).Result()
+	if err != nil {
+		return nil, "", common.NewErrorE(http.StatusInternalServerError, err)
+	}
+	return objs, etag, nil
+}
+{{- end}}
+
+
 func (c *{{$cacheName}}) Delete({{$ID | ToLower}} string) *common.Error {
 	{{if .SecondaryIndexes -}}
 	o, _, lerr := c.Get({{$ID | ToLower}})
@@ -574,6 +623,14 @@ func (c *{{$cacheName}}) Delete({{$ID | ToLower}} string) *common.Error {
 	if err != nil {
 		return common.NewErrorE(http.StatusInternalServerError, err)
 	}
+
+	{{if .GetAll -}}
+	c.Leader.SRem(context.TODO(), c.Key({{$cacheKey}}All, {{$cacheKey}}All), {{$ID | ToLower}})
+	err = c.Leader.Incr(context.TODO(), c.ETagKey({{$cacheKey}}All, {{$cacheKey}}All)).Err()
+	if err != nil {
+		return common.NewErrorE(http.StatusInternalServerError, err)
+	}
+	{{ end }}
 
 	{{range .SecondaryIndexes -}}
 	{{if eq .Type "set"}}


### PR DESCRIPTION
- Required by partner service `GetAllByPartner("")` - hax to list all partners since old code used to filter by prefix
- New key `GetAll` (defaults to `false`) creates and maintains a set of all object IDs in the cache
- Removed `InclPartnerID` since it will be removed anyway
- Attempt to run `go fmt` on generated files