### PR TITLE
Add singleton store and fix error propagation

### DIFF
--- a/encrypted_store.go
+++ b/encrypted_store.go
@@ -38,7 +38,7 @@ func NewEncryptedStore(backend LingioStore, cipherKey string) (*EncryptedStore, 
 	}, nil
 }
 
-func (es *EncryptedStore) GetObject(file string) ([]byte, ObjectInfo, error) {
+func (es *EncryptedStore) GetObject(file string) ([]byte, ObjectInfo, *Error) {
 	data, info, err := es.backend.GetObject(es.encryptFilename(file))
 	if err != nil {
 		return nil, ObjectInfo{}, err
@@ -48,7 +48,7 @@ func (es *EncryptedStore) GetObject(file string) ([]byte, ObjectInfo, error) {
 	return data, info, nil
 }
 
-func (es *EncryptedStore) PutObject(ctx context.Context, file string, data []byte) (ObjectInfo, error) {
+func (es *EncryptedStore) PutObject(ctx context.Context, file string, data []byte) (ObjectInfo, *Error) {
 	es.cipher.Encrypt(data, data)
 	info, err := es.backend.PutObject(ctx, es.encryptFilename(file), data)
 	if err != nil {
@@ -58,7 +58,7 @@ func (es *EncryptedStore) PutObject(ctx context.Context, file string, data []byt
 	return info, nil
 }
 
-func (es EncryptedStore) DeleteObject(ctx context.Context, file string) error {
+func (es EncryptedStore) DeleteObject(ctx context.Context, file string) *Error {
 	return es.backend.DeleteObject(ctx, es.encryptFilename(file))
 }
 

--- a/lingio_store.go
+++ b/lingio_store.go
@@ -17,9 +17,9 @@ func (b *AtomicBool) SetFalse()   { atomic.StoreInt32((*int32)(b), 0) }
 
 // LingioStore is a simple file-based CRUD database interface.
 type LingioStore interface {
-	GetObject(file string) ([]byte, ObjectInfo, error)
-	PutObject(ctx context.Context, file string, data []byte) (ObjectInfo, error)
-	DeleteObject(ctx context.Context, file string) error
+	GetObject(file string) ([]byte, ObjectInfo, *Error)
+	PutObject(ctx context.Context, file string, data []byte) (ObjectInfo, *Error)
+	DeleteObject(ctx context.Context, file string) *Error
 	ListObjects(context.Context) <-chan ObjectInfo
 }
 

--- a/redis_cache.go
+++ b/redis_cache.go
@@ -114,13 +114,6 @@ func (c RedisCache) Live() bool {
 	} else if val != "PONG" {
 		return false
 	}
-
-	if val, err := c.Ping(context.TODO()).Result(); err != nil {
-		return false
-	} else if val != "PONG" {
-		return false
-	}
-
 	return true
 }
 

--- a/script/encrypt/main.go
+++ b/script/encrypt/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/lingio/go-common"
@@ -70,28 +71,28 @@ func trap(err error) {
 }
 
 // GetObject is supposed to be called when we're trying to decrypt an encrypted stdin.
-func (ds dummyStore) GetObject(filename string) ([]byte, common.ObjectInfo, error) {
+func (ds dummyStore) GetObject(filename string) ([]byte, common.ObjectInfo, *common.Error) {
 	var obj Object
 	if err := ds.decoder.Decode(&obj); err != nil {
-		return nil, common.ObjectInfo{}, err
+		return nil, common.ObjectInfo{}, common.NewErrorE(http.StatusInternalServerError, err)
 	}
 	return obj.Data, obj.ObjectInfo, nil
 }
 
 // PutObject is supposed to be called when we're trying to encrypt a plain-text stdin.
-func (ds dummyStore) PutObject(ctx context.Context, file string, data []byte) (common.ObjectInfo, error) {
+func (ds dummyStore) PutObject(ctx context.Context, file string, data []byte) (common.ObjectInfo, *common.Error) {
 	if err := ds.encoder.Encode(Object{
 		Data: data,
 		ObjectInfo: common.ObjectInfo{
 			Key: file,
 		},
 	}); err != nil {
-		return common.ObjectInfo{}, err
+		return common.ObjectInfo{}, common.NewErrorE(http.StatusInternalServerError, err)
 	}
 	return common.ObjectInfo{}, nil
 }
 
-func (ds dummyStore) DeleteObject(ctx context.Context, file string) error {
+func (ds dummyStore) DeleteObject(ctx context.Context, file string) *common.Error {
 	return nil
 }
 func (ds dummyStore) ListObjects(ctx context.Context) <-chan common.ObjectInfo {

--- a/storagegen/tmpl/blobstore.tmpl
+++ b/storagegen/tmpl/blobstore.tmpl
@@ -85,10 +85,8 @@ func (s *{{$storeName}}) Put(ctx context.Context, id string, blob models.{{.DbTy
 
 // put does the heavy lifting for both Put and Create methods.
 func (s *{{$storeName}}) put(ctx context.Context, id string, blob models.{{.DbTypeName}}) *common.Error {
-	_, err := s.backend.PutObject(ctx, s.filename(id), blob)
-	if err != nil {
-		return common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", id).Msg("failed to write to minio")
+	if _, err := s.backend.PutObject(ctx, s.filename(id), blob); err != nil {
+		return err.Str("ID", id).Msg("failed to write to minio")
 	}
 	return nil
 }

--- a/storagegen/tmpl/blobstore.tmpl
+++ b/storagegen/tmpl/blobstore.tmpl
@@ -73,8 +73,7 @@ func (s *{{$storeName}}) Create(ctx context.Context, blob models.{{.DbTypeName}}
 func (s *{{$storeName}}) Get(id string) (*models.{{.DbTypeName}}, string, *common.Error) {
 	data, info, err := s.backend.GetObject(id)
 	if err != nil {
-		return nil, "", common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", id).Msg("failed to get from minio")
+		return nil, "", err
 	}
 	return (*models.{{.DbTypeName}})(&data), info.ETag, nil
 }
@@ -102,4 +101,3 @@ func (s *{{$storeName}}) Delete(ctx context.Context, id string) *common.Error {
 	}
 	return nil
 }
-

--- a/storagegen/tmpl/blobstore.tmpl
+++ b/storagegen/tmpl/blobstore.tmpl
@@ -71,7 +71,7 @@ func (s *{{$storeName}}) Create(ctx context.Context, blob models.{{.DbTypeName}}
 
 // Get attempts to load an byte blob with the specified ID from the store.
 func (s *{{$storeName}}) Get(id string) (*models.{{.DbTypeName}}, string, *common.Error) {
-	data, info, err := s.backend.GetObject(id)
+	data, info, err := s.backend.GetObject(s.filename(id))
 	if err != nil {
 		return nil, "", err
 	}
@@ -101,3 +101,4 @@ func (s *{{$storeName}}) Delete(ctx context.Context, id string) *common.Error {
 	}
 	return nil
 }
+

--- a/storagegen/tmpl/cachedstore.tmpl
+++ b/storagegen/tmpl/cachedstore.tmpl
@@ -173,10 +173,9 @@ func (s *{{$storeName}}) put(ctx context.Context, obj models.{{.DbTypeName}}) *c
 		return common.NewErrorE(http.StatusInternalServerError, err).
 			Str("ID", obj.{{.IdName}}).Msg("failed to marshal json")
 	}
-	info, err := s.backend.PutObject(ctx, s.filename(obj.{{.IdName}}), data)
-	if err != nil {
-		return common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", obj.{{.IdName}}).Msg("failed to write to minio")
+	info, lerr := s.backend.PutObject(ctx, s.filename(obj.{{.IdName}}), data)
+	if lerr != nil {
+		return lerr.Str("ID", obj.{{.IdName}}).Msg("failed to write to minio")
 	}
 
 	var expiration time.Duration
@@ -189,8 +188,7 @@ func (s *{{$storeName}}) put(ctx context.Context, obj models.{{.DbTypeName}}) *c
 // Delete
 func (s *{{$storeName}}) Delete(ctx context.Context, id string) *common.Error {
 	if err := s.backend.DeleteObject(ctx, s.filename(id)); err != nil {
-		return common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", id).Msg("failed to delete object in minio")
+		return err.Str("ID", id).Msg("failed to delete object in minio")
 	}
 	return s.cache.Delete(id)
 }

--- a/storagegen/tmpl/common.tmpl
+++ b/storagegen/tmpl/common.tmpl
@@ -11,15 +11,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/tags"
 )
 
-func minioErrToCommonErr(err error) *common.Error {
-	minioErr := err.(minio.ErrorResponse)
-	return common.NewErrorE(minioErr.StatusCode, err).
-		Str("minio.Message", minioErr.Message).
-		Str("minio.Code", minioErr.Code).
-		Str("minio.BucketName", minioErr.BucketName).
-		Str("minio.Key", minioErr.Key)
-}
-
 func writePartnerBucketETag(c *minio.Client, bucketName string, partnerID string, etag string) *common.Error {
 	// Write ETag
 	bucketTags, err := tags.MapToBucketTags(map[string]string{fmt.Sprintf("%s-etag", partnerID): etag})

--- a/storagegen/tmpl/directstore.tmpl
+++ b/storagegen/tmpl/directstore.tmpl
@@ -93,9 +93,8 @@ func (s *{{$storeName}}) Create(ctx context.Context, obj models.{{.DbTypeName}})
 // Get attempts to load an object with the specified ID from the store.
 func (s *{{$storeName}}) Get(id string) (*models.{{.DbTypeName}}, string, *common.Error) {
 	data, info, err := s.backend.GetObject(id)
-	if err != nil {
-		return nil, "", common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", id).Msg("failed to get from minio")
+	if lerr != nil {
+		return nil, "", lerr
 	}
 	obj := &models.{{.DbTypeName}}{}
 	if err := json.Unmarshal(data, &obj); err != nil {
@@ -117,10 +116,9 @@ func (s *{{$storeName}}) put(ctx context.Context, obj models.{{.DbTypeName}}) *c
 		return common.NewErrorE(http.StatusInternalServerError, err).
 			Str("ID", obj.{{.IdName}}).Msg("failed to marshal json")
 	}
-	info, err := s.backend.PutObject(ctx, s.filename(obj.{{.IdName}}), data)
-	if err != nil {
-		return common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", obj.{{.IdName}}).Msg("failed to write to minio")
+	_, lerr := s.backend.PutObject(ctx, s.filename(obj.{{.IdName}}), data)
+	if lerr != nil {
+		return lerr.Str("ID", obj.{{.IdName}}).Msg("failed to write to minio")
 	}
 	return nil
 }
@@ -128,8 +126,7 @@ func (s *{{$storeName}}) put(ctx context.Context, obj models.{{.DbTypeName}}) *c
 // Delete
 func (s *{{$storeName}}) Delete(ctx context.Context, id string) *common.Error {
 	if err := s.backend.DeleteObject(ctx, s.filename(id)); err != nil {
-		return common.NewErrorE(http.StatusInternalServerError, err).
-			Str("ID", id).Msg("failed to delete object in minio")
+		return err.Str("ID", id).Msg("failed to delete object in minio")
 	}
 	return nil
 }

--- a/storagegen/tmpl/directstore.tmpl
+++ b/storagegen/tmpl/directstore.tmpl
@@ -5,15 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/lingio/{{.ServiceName}}/models"
 
 	"github.com/lingio/go-common"
 	"github.com/minio/minio-go/v7"
 	uuid "github.com/satori/go.uuid"
-
-	zl "github.com/rs/zerolog/log"
 )
 
 {{$modelName := .DbTypeName -}}
@@ -64,7 +61,7 @@ func (s *{{$storeName}}) filename(id string) string {
 }
 
 //=============================================================================
-// Lingio store implementation
+// Store implementation
 //=============================================================================
 
 // Create attempts to store the provided object in store.

--- a/storagegen/tmpl/directstore.tmpl
+++ b/storagegen/tmpl/directstore.tmpl
@@ -92,7 +92,7 @@ func (s *{{$storeName}}) Create(ctx context.Context, obj models.{{.DbTypeName}})
 
 // Get attempts to load an object with the specified ID from the store.
 func (s *{{$storeName}}) Get(id string) (*models.{{.DbTypeName}}, string, *common.Error) {
-	data, info, err := s.backend.GetObject(id)
+	data, info, lerr := s.backend.GetObject(s.filename(id))
 	if lerr != nil {
 		return nil, "", lerr
 	}

--- a/storagegen/tmpl/singlestore.tmpl
+++ b/storagegen/tmpl/singlestore.tmpl
@@ -1,0 +1,139 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/lingio/{{.ServiceName}}/models"
+
+	"github.com/lingio/go-common"
+	"github.com/minio/minio-go/v7"
+)
+
+{{$modelName := .DbTypeName -}}
+{{$storeName := printf "%sStore" .TypeName -}}
+
+var {{$storeName}}Config common.ObjectStoreConfig
+func init() {
+	err := json.Unmarshal([]byte(`
+{{.Config | PrettyPrint}}
+	`), &{{$storeName}}Config)
+	if err != nil {
+		panic(fmt.Errorf("error parsing store config: %w", err))
+	}
+}
+
+type {{$storeName}} struct {
+	backend common.LingioStore
+}
+
+// New{{$storeName}} configures a new store and initializes the provided cache if required.
+func New{{$storeName}}(mc *minio.Client, serviceKey string) (*{{$storeName}}, error) {
+	// DefaultOjbectStoreConfig || deserialize
+	objectStore, err := common.NewObjectStore(mc, "{{.BucketName}}", {{$storeName}}Config)
+	if err != nil {
+		return nil, fmt.Errorf("creating object store: %w", err)
+	}
+
+	encryptedStore, err := common.NewEncryptedStore(objectStore, serviceKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating encrypted store: %w", err)
+	}
+
+	db := &{{$storeName}}{
+		backend: encryptedStore,
+	}
+
+	return db, nil
+}
+
+// filename returns the name of the one file in this store
+func (s *{{$storeName}}) filename() string {
+	{{ if .FilenameFormat -}}
+	return "{{.FilenameFormat}}"
+	{{- else -}}
+	panic("no filename configured")
+	{{- end }}
+}
+
+//=============================================================================
+// Store implementation
+//=============================================================================
+
+// Create attempts to store the provided object in store.
+func (s *{{$storeName}}) Create(ctx context.Context, obj models.{{.DbTypeName}}) (*models.{{.DbTypeName}}, *common.Error) {
+	// check that the object doesn't exist
+	o, _, err := s.Get()
+	if err != nil && err.HttpStatusCode != http.StatusNotFound {
+		return nil, common.NewErrorE(http.StatusInternalServerError, err).
+			Msg("failed query for object")
+	}
+	if o != nil { // object exists!
+		return nil, common.NewError(http.StatusBadRequest).
+			Msg("an object is already stored in the database")
+	}
+	if err := s.put(ctx, obj); err != nil {
+		return nil, err
+	}
+	return &obj, nil
+}
+
+
+// Get attempts to load the singleton from the store.
+func (s *{{$storeName}}) Get() (*models.{{.DbTypeName}}, string, *common.Error) {
+	data, info, lerr := s.backend.GetObject(s.filename())
+	if lerr != nil {
+		return nil, "", lerr.Msg("failed to get from minio")
+	}
+	obj := &models.{{.DbTypeName}}{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, "", common.NewErrorE(http.StatusInternalServerError, err).
+			Msg("failed to unmarshal json")
+	}
+	return obj, info.ETag, nil
+}
+
+// Put updates or creates the object in both cache and backing store.
+func (s *{{$storeName}}) Put(ctx context.Context, obj models.{{.DbTypeName}}) *common.Error {
+	return s.put(ctx, obj)
+}
+
+// put does the heavy lifting for both Put and Create methods.
+func (s *{{$storeName}}) put(ctx context.Context, obj models.{{.DbTypeName}}) *common.Error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return common.NewErrorE(http.StatusInternalServerError, err).
+			Msg("failed to marshal json")
+	}
+	if _, lerr := s.backend.PutObject(ctx, s.filename(), data); lerr != nil {
+		return lerr.Msg("failed to write to minio")
+	}
+	return nil
+}
+
+// Delete
+func (s *{{$storeName}}) Delete(ctx context.Context) *common.Error {
+	if err := s.backend.DeleteObject(ctx, s.filename()); err != nil {
+		return err.Msg("failed to delete object in minio")
+	}
+	return nil
+}
+
+//=============================================================================
+// Extra functions from secondary indexes, passes to cache layer
+//=============================================================================
+{{range .SecondaryIndexes -}}
+{{if eq .Type "unique"}}
+// GetBy{{.Name}} fetches a single {{$modelName}} by its {{.Key}}
+func (s *{{$storeName}}) GetBy{{.Name}}(key string) (*models.{{$modelName}}, string, *common.Error) {
+	panic("not yet implemented")
+}
+{{else if eq .Type "set"}}
+// GetAllBy{{.Name}} fetches all {{$modelName}}s by their {{.Key}}
+func (s *{{$storeName}}) GetAllBy{{.Name}}(key string) ([]models.{{$modelName}}, string, *common.Error) {
+	panic("not yet implemented")
+}
+{{end -}}
+{{end}}


### PR DESCRIPTION
This PR adds a new store template: `singlestore.tmpl` for managing exactly one object, as used by the api key chain store.

It also fixes a number of error propagation quirks regarding implicit 404 => object not found-style handling being broken.

Stores for services should be regenerated after this PR is merged.