### PR TITLE
Detect and remove previously cached entries

### DIFF
--- a/storagegen/tmpl/blobstore.tmpl
+++ b/storagegen/tmpl/blobstore.tmpl
@@ -51,8 +51,12 @@ func New{{$storeName}}(mc *minio.Client, serviceKey string) (*{{$storeName}}, er
 }
 
 // filename map typed values to a string
-func (ps *{{$storeName}}) filename(id string) string {
-	return fmt.Sprintf("%s.json", id)
+func (s *{{$storeName}}) filename(id string) string {
+	{{ if .FilenameFormat -}}
+	return fmt.Sprintf("{{.FilenameFormat}}", id)
+	{{- else -}}
+	return id + ".json"
+	{{- end }}
 }
 
 //=============================================================================

--- a/storagegen/tmpl/cachedstore.tmpl
+++ b/storagegen/tmpl/cachedstore.tmpl
@@ -474,22 +474,28 @@ func (c {{$cacheName}}) Put(obj models.{{.DbTypeName}}, expiration time.Duration
 	{{end -}}
 	{{end}}
 
+
 	{{- /* Remove old indexes if keys changed. */}}
 	// Delete old secondary indexes if they changed
 	if orig != nil {
 		{{range .SecondaryIndexes -}}
 		{{if eq .Type "unique" -}}
+		// {{ .Name }} depends on ({{ .Keys | Materialize "" | Join ", " }})
 		{{if .Optional -}}
-		if {{ .Keys | CheckOptional "obj" | Join " && " }} && {{ .Keys | CheckOptional "orig" | Join " && " }} && {{ .Keys | CompareFields "obj" "orig" " != " | Join " && "}} {
-			idx = CompoundIndex({{ .Keys | Materialize "obj" | Join ", " }})
-			err := c.Client.Del(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx)).Err()
-			if err != nil {
-				return common.NewErrorE(http.StatusInternalServerError, err)
+		{
+			oldExists := {{ .Keys | CheckOptional "orig" | Join " && " }}
+			newNil := !({{ .Keys | CheckOptional "obj" | Join " && " }})
+			if (oldExists && newNil) || (oldExists && !newNil && ({{ .Keys | CompareFields "obj" "orig" " != " | Join " || "}})) {
+				idx := CompoundIndex({{ .Keys | Materialize "orig" | Join ", " }})
+				err := c.Client.Del(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx)).Err()
+				if err != nil {
+					return common.NewErrorE(http.StatusInternalServerError, err)
+				}
 			}
 		}
 		{{- else -}}
-		if {{ .Keys | CompareFields "obj" "orig" " != " | Join " && " }} {
-			idx = CompoundIndex({{ .Keys | Materialize "obj" | Join ", " }})
+		if {{ .Keys | CompareFields "obj" "orig" " != " | Join " || " }} {
+			idx = CompoundIndex({{ .Keys | Materialize "orig" | Join ", " }})
 			err := c.Client.Del(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx)).Err()
 			if err != nil {
 				return common.NewErrorE(http.StatusInternalServerError, err)
@@ -501,18 +507,23 @@ func (c {{$cacheName}}) Put(obj models.{{.DbTypeName}}, expiration time.Duration
 		{{- /* */ -}}
 		{{range .SecondaryIndexes -}}
 		{{if eq .Type "set"}}
+		// {{ .Name }} depends on ({{ .Keys | Materialize "" | Join ", " }})
 		{{ if .Optional -}}
-		if {{ .Keys | CheckOptional "obj" | Join " && " }} && {{ .Keys | CheckOptional "orig" | Join " && " }} && {{ .Keys | CompareFields "obj" "orig" " != " | Join " && "}} {
-			idx = CompoundIndex({{ .Keys | Materialize "obj" | Join ", " }})
-			c.Client.SRem(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx), orig.{{$ID}})
-			err := c.Client.Incr(context.TODO(), c.ETagKey({{$cacheKey}}{{.Name}}, idx)).Err()
-			if err != nil {
-				return common.NewErrorE(http.StatusInternalServerError, err)
+		{
+			oldExists := {{ .Keys | CheckOptional "orig" | Join " && " }}
+			newNil := !({{ .Keys | CheckOptional "obj" | Join " && " }})
+			if (oldExists && newNil) || (oldExists && !newNil && ({{ .Keys | CompareFields "obj" "orig" " != " | Join " || "}})) {
+				idx = CompoundIndex({{ .Keys | Materialize "orig" | Join ", " }})
+				c.Client.SRem(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx), orig.{{$ID}})
+				err := c.Client.Incr(context.TODO(), c.ETagKey({{$cacheKey}}{{.Name}}, idx)).Err()
+				if err != nil {
+					return common.NewErrorE(http.StatusInternalServerError, err)
+				}
 			}
 		}
 		{{- else -}}
-		if {{ .Keys | CompareFields "obj" "orig" " != " | Join " && " }} {
-			idx = CompoundIndex({{ .Keys | Materialize "obj" | Join ", " }})
+		if {{ .Keys | CompareFields "obj" "orig" " != " | Join " || " }} {
+			idx = CompoundIndex({{ .Keys | Materialize "orig" | Join ", " }})
 			c.Client.SRem(context.TODO(), c.Key({{$cacheKey}}{{.Name}}, idx), orig.{{$ID}})
 			err := c.Client.Incr(context.TODO(), c.ETagKey({{$cacheKey}}{{.Name}}, idx)).Err()
 			if err != nil {


### PR DESCRIPTION
This PR includes two important fixes.

Fix which affects services using compound indexes of both type `set` and `unique`:

- person service: https://github.com/lingio/person-service/pull/63

Also removes the correct compound key, which affects all services using secondary indexes:

- `auto-test-service/PartnerTest`: https://github.com/lingio/auto-test-service/pull/9
- `course-schedule/Class`: https://github.com/lingio/course-schedule/pull/78

```bash
cd ~/work/lingio/
# First bug: changes in compound indexes are not detected 
grep secondaryIndexes -l -r ./ | grep spec | xargs -I {} cat {} | jq '.serviceName + "/" + (.buckets[] | select(.secondaryIndexes[] | .keys | length > 0) | .typeName)' | sort | uniq
# Second bug: wrong compound index is removed if changed
grep secondaryIndexes -l -r ./ | grep spec | xargs -I {} cat {} | jq '.serviceName + "/" + (.buckets[] | select(.secondaryIndexes[]  | length > 0) | .typeName)' | sort | uniq
```