### PR TITLE
New error functionality

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -87,7 +87,7 @@ func (e *Error) Str(k string, v string) *Error {
 
 func (e *Error) Int(k string, v int) *Error {
 	e.ensureMapNotNil()
-	e.Map[k] = fmt.Sprintf("%d", v)
+	e.Map[k] = strconv.Itoa(v)
 	return e
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -33,6 +34,29 @@ func (e *Error) Error() string {
 	str.WriteString(". message: ")
 	str.WriteString(e.Message)
 	str.WriteString(".")
+	return str.String()
+}
+
+func (e *Error) FullTrace() string {
+	var str strings.Builder
+	str.WriteString(e.Trace)
+
+	err := error(e)
+	for {
+		err = errors.Unwrap(err)
+		if err == nil {
+			break
+		}
+		str.WriteString("\n")
+		str.WriteString(" \\")
+		if lerr, ok := err.(*Error); ok {
+			str.WriteString(lerr.Trace)
+			str.WriteString(": ")
+			str.WriteString(lerr.Message)
+		} else {
+			str.WriteString(err.Error())
+		}
+	}
 	return str.String()
 }
 

--- a/errors.go
+++ b/errors.go
@@ -84,8 +84,21 @@ func (e *Error) ensureMapNotNil() {
 	}
 }
 
+// Unwrap implements returns the underlying error type for errors.Unwrap(err)
 func (e *Error) Unwrap() error {
 	return e.err
+}
+
+// Is returns whether the target error is the same as this one, useful for errors.Is:
+//   errors.Is(myError, ErrObjectDoesNotExist)
+func (e *Error) Is(target error) bool {
+	if e.err == target {
+		return true
+	} else if err, ok := target.(*Error); ok {
+		return err.HttpStatusCode == e.HttpStatusCode && err.Message == e.Message
+	} else {
+		return false
+	}
 }
 
 func getErrorTrace() string {
@@ -95,4 +108,5 @@ func getErrorTrace() string {
 	}
 	filename = filepath.Base(filename)
 	return fmt.Sprintf("%v:%v", filename, line)
+
 }


### PR DESCRIPTION
- Add `Is` method to support `errors.Is(lingioError, common.ErrObjectDoesNotExist)`-type of error handling
- Add `FullTrace` method to get full error trace
- Rework `ObjectStore` error handling to indentify some specific minio error cases, such as `ErrObjectNotFound`

NOTES

- backwards-compatible with `http.StatusNotFound`-error checking code

TODO

- support capturing error trace for error origins more than 2 calls away: 
```golang

func X() error {
	val, err := SomeFunc()
	if err != nil {
		return NewErrorE(0, err) // captures accurate error trace
	}
	val2, err := SomeOtherFunc()
	if err != nil {
		return errorParseFunc(err) // captures error trace in errorParseFunc
	}
}

func errorParseFunc(err error) *Error {
	return NewErrorE(0, err)
}

```