### PR TITLE
cached store: only cache objects with canonical filename

### DIFF
--- a/storagegen/tmpl/cachedstore.tmpl
+++ b/storagegen/tmpl/cachedstore.tmpl
@@ -342,6 +342,11 @@ func (c *{{$cacheName}}) Init(backend common.LingioStore) (resulterr error) {
 							return
 						}
 
+						if info.Key != {{$filename}}(entity.{{.IdName}}) {
+							zl.Warn().Str("key", info.Key).Msg("skipping object with mismatched filename")
+							continue
+						}
+
 						workerout <- {{.TypeName}}CacheIngest{
 							ObjectInfo: info,
 							Entity:     entity,


### PR DESCRIPTION
Assume we have two duplicate objects (with different filenames) in a bucket:

```
{ key: "x-1.json", data: { id: "someid" } }
{ key: "1.json", data: { id: "someid" } }
```

the object store system should obviously only read and write one of them. But which one?

In `directstore` this is a non-issue since we will consult `spec.FilenameFormat` and always read/write using the correct filename.

However, in `cachedstore` we list all objects in the store and if there are duplicated IDs we don't know which one we will havein the cache after cache init. Writes will always go to the `spec.FilenameFormat` object. 

This PR filters out objects with filenames that don't match the expected `spec.FilenameFormat` during cache init.