### PR TITLE
Fix logged request status field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lingio/go-common
 
-go 1.18
+go 1.20
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.13.1


### PR DESCRIPTION
- status code in request log is extracted from `HTTPError`, currently failed requests have incorrect status in log (but correct in http headers)
- `Error.Unwrap()` now returns `[]error`: the underlying error + `echo.HTTPError` with status/message from itself
- echo's default error handler does not call `errors.As` so we still need a custom error handler
