### PR TITLE
Add support for google Cloud Logging and Cloud Trace

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,9 +25,12 @@ type RedisConfig struct {
 
 type MonitorConfig struct {
 	TempoHost  string
-	CloudTrace struct {
-		Enabled bool
-	}
+	CloudTrace CloudTraceConfig
+}
+
+type CloudTraceConfig struct {
+	ProjectID string
+	Enabled   bool
 }
 
 func MustGetenv(key string) string {

--- a/env.go
+++ b/env.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"os"
 	"strings"
+
+	zl "github.com/rs/zerolog/log"
 )
 
 type Environment string
@@ -15,39 +16,47 @@ var (
 )
 
 type Env struct {
-	EnvName    string
+	EnvName string
+	// GCP project ID.
 	ProjectID  string
 	ConfigFile string
+	Environment
 }
 
 func SetupEnv() *Env {
-	env := os.Getenv("ENV")
-	switch ParseEnv() {
+	return env
+}
+
+func setupEnv() *Env {
+	envstr := MustGetenv("ENV")
+	switch env := ParseEnv(envstr); env {
 	case EnvDevelop:
 		return &Env{
-			EnvName:    env,
-			ProjectID:  "lingio-stage",
-			ConfigFile: env,
+			EnvName:     envstr,
+			ProjectID:   "lingio-stage",
+			ConfigFile:  envstr,
+			Environment: env,
 		}
 	case EnvStaging:
 		return &Env{
-			EnvName:    env,
-			ProjectID:  "lingio-stage",
-			ConfigFile: env,
+			EnvName:     envstr,
+			ProjectID:   "lingio-stage",
+			ConfigFile:  envstr,
+			Environment: env,
 		}
 	case EnvProduction:
 		return &Env{
-			EnvName:    env,
-			ProjectID:  "lingio-prod",
-			ConfigFile: env,
+			EnvName:     envstr,
+			ProjectID:   "lingio-prod",
+			ConfigFile:  envstr,
+			Environment: env,
 		}
 	}
-	panic("SetupEnv: unknown env: " + env)
+	zl.Fatal().Msgf("setupEnv: unknown env %q", envstr)
+	return nil
 }
 
-func ParseEnv() Environment {
-	env := os.Getenv("ENV")
-
+func ParseEnv(env string) Environment {
 	// prod, production, production-glesys
 	if strings.HasPrefix(env, "prod") {
 		return EnvProduction
@@ -61,5 +70,6 @@ func ParseEnv() Environment {
 	if strings.HasPrefix(env, "local") {
 		return EnvDevelop
 	}
+
 	return EnvUnknown
 }

--- a/init.go
+++ b/init.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	env *Env = setupEnv()
+)
+
+func init() {
+	// setup uniform logging fields asap so we get them everywhere
+	zerolog.LevelFieldName = "severity"
+	zerolog.TimestampFieldName = "timestamp"
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+
+	// replace the default logger
+	log.Logger = setupZerologger()
+}

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	echomiddleware "github.com/labstack/echo/v4/middleware"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func InitLogging() {
+	zerolog.LevelFieldName = "severity"
+	zerolog.TimestampFieldName = "timestamp"
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+}
+
+type RequestLogFormatter func(c echo.Context, v echomiddleware.RequestLoggerValues) error
+type RequestLogger func(http.ResponseWriter) zerolog.Logger
+
+func gcpRequestLogFormatter(c echo.Context, v echomiddleware.RequestLoggerValues) error {
+	var (
+		spanCtx = trace.SpanFromContext(c.Request().Context()).SpanContext()
+
+		// log level info if v.Error is nil, otherwise error
+		zle = zerolog.Ctx(c.Request().Context()).Err(v.Error)
+	)
+
+	zle.
+		// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+		Dict("httpRequest",
+			zerolog.Dict().
+				Str("requestMethod", v.Method).
+				Str("requestUrl", v.URI).
+				Str("requestSize", v.ContentLength). // sent by client
+				Int("status", v.Status).
+				Str("responseSize", strconv.FormatInt(v.ResponseSize, 10)).
+				Str("userAgent", v.UserAgent).
+				Str("remoteIp", v.RemoteIP).
+				// Str("serverIp", v.ServerIP) // does not exit
+				Str("referer", v.Referer).
+				Str("latency", v.Latency.String()).
+				// Bool("cacheLookup", false) // does not exit
+				// Bool("cacheHit", false) // does not exit
+				// Bool("cacheValidatedWithOriginServer", false) // does not exit
+				// Str("cacheFillBytes", "") // does not exit
+				Str("protocol", v.Protocol),
+		).
+		Str("path", v.RoutePath). // /users/:userid
+		Str("logging.googleapis.com/trace", "/projects/lingio-stage/traces/"+spanCtx.TraceID().String()).
+		Str("logging.googleapis.com/spanId", spanCtx.SpanID().String()).
+		Bool("logging.googleapis.com/trace_sampled ", spanCtx.IsSampled())
+
+	// https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+	//
+	// ... If your log entry contains an exception stack trace, the exception
+	// stack trace should be set in this message JSON log field, ...
+	//
+	if v.Error != nil {
+		zle.Msg(FullErrorTrace(v.Error))
+	} else {
+		zle.Msg("request") // actually log it
+	}
+	return nil
+}
+
+func defaultRequestLogFormatter(c echo.Context, v echomiddleware.RequestLoggerValues) error {
+	var (
+		span = trace.SpanFromContext(c.Request().Context())
+
+		// log level info if v.Error is nil, otherwise error
+		zle = zerolog.Ctx(c.Request().Context()).Err(v.Error)
+	)
+
+	zle.Str("host", v.Host).
+		Str("remote_ip", v.RemoteIP).
+		Str("user_agent", v.UserAgent).
+		Str("protocol", v.Protocol).
+		Str("method", v.Method).
+		Str("uri", v.URI).        // /users/5?q=1
+		Str("path", v.RoutePath). // /users/:userid
+		Int("status", v.Status).
+		Int64("latency_us", v.Latency.Microseconds()).
+		Str("latency_human", v.Latency.String()).
+		Str("bytes_in", v.ContentLength).
+		Int64("bytes_out", v.ResponseSize).
+		Str("trace_id", span.SpanContext().TraceID().String())
+
+	if v.Error != nil {
+		zle.Str("full_trace", FullErrorTrace(v.Error))
+	}
+
+	zle.Msg("request") // actually log it
+
+	return nil
+}
+
+var _ RequestLogFormatter = gcpRequestLogFormatter
+var _ RequestLogFormatter = defaultRequestLogFormatter
+
+func gcpRequestLogger(w http.ResponseWriter) zerolog.Logger {
+	return zerolog.New(os.Stderr).With().
+		Timestamp().
+		Dict("logging.googleapis.com/operation",
+			zerolog.Dict().
+				Str("id", w.Header().Get(echo.HeaderXRequestID)),
+		).
+		Logger()
+
+}
+
+func defaultRequestLog(w http.ResponseWriter) zerolog.Logger {
+	return zerolog.New(os.Stderr).With().
+		Timestamp().
+		Str("correlation_id", w.Header().Get(echo.HeaderXRequestID)).
+		Logger()
+
+}
+
+var _ RequestLogger = gcpRequestLogger

--- a/remote.go
+++ b/remote.go
@@ -167,14 +167,11 @@ func executeReq(req *http.Request) ([]byte, error) {
 			return nil, NewError(resp.StatusCode).
 				Str("host", req.URL.Host).
 				Str("url", req.URL.Path).
-				Int("remoteStatusCode", resp.StatusCode).
-				Msg("remote error without message")
+				Msg("unknown remote error")
 		}
 		return nil, NewError(resp.StatusCode).
 			Str("url", req.URL.Path).
-			Int("remoteStatusCode", resp.StatusCode).
-			Str("remoteError", x.Message).
-			Msg("remote error")
+			Msg(x.Message)
 	}
 	return data, nil
 }


### PR DESCRIPTION
- services will in `local-` env print txt output instead of json, and only print message or error trace
- group logs by correlation id (operation.id in google speech)
- see httpRequest details in google log explorer
- hopefully link a log to a trace and vice versa