### PR TITLE
Implement spanner helper for string types

### DIFF
--- a/audit_log_test.go
+++ b/audit_log_test.go
@@ -44,7 +44,7 @@ func TestAuditLog(t *testing.T) {
 	// 	t.Fatalf(`'authID' not found or invalid: %v (%v), expected '%v'`, authID, ok, "AUTH")
 	// }
 
-	if _, ok := logmsg["time"]; !ok {
+	if _, ok := logmsg["timestamp"]; !ok {
 		t.Fatalf(`timestamp not found`)
 	}
 }

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestEncodeSpannerStructFields(t *testing.T) {
+	type StrType string
+
 	testcases := []struct {
 		name   string
 		source any
@@ -90,6 +92,12 @@ func TestEncodeSpannerStructFields(t *testing.T) {
 				X int64
 				M string `spannerType:"jsonstring"`
 			}{"X", 100, "{\"COMPLEX\":{\"SUBKEY\":99},\"SECRET\":\"42\"}"},
+		},
+		{
+			name:   "locally defined string type",
+			source: &struct{ S StrType }{StrType("hej")},
+			target: &struct{ S string }{},
+			wanted: &struct{ S string }{"hej"},
 		},
 	}
 


### PR DESCRIPTION
spanner helpers now supports encode/decode between `Game` and `SpannerGame` as below

```
type GameMode string

type Game struct {
    Mode GameMode
}
type SpannerGame {
    Mode string
}
```